### PR TITLE
Added statement that shows error message and version in which occued

### DIFF
--- a/AppSource/AppSourceValidation.kql
+++ b/AppSource/AppSourceValidation.kql
@@ -1,3 +1,8 @@
 traces
 | where customDimensions.eventId == 'LC0034'
 | order by timestamp desc 
+
+traces
+| where customDimensions has "LC0034"
+| where customDimensions.diagnosticMessage != ''
+| summarize count() by diagnosticMessage = tostring(customDimensions.diagnosticMessage), version = tostring(customDimensions.version)


### PR DESCRIPTION
Added statement that shows error message and version in which occued during appsource validation. Since Validation for many countries give the same messages it is grouped to not double the records.

I think it can be useful during validation process. 

![image](https://github.com/waldo1001/waldo.BCTelemetry/assets/104026807/ffa0d1f1-8c64-4089-ba38-d8026215006a)
